### PR TITLE
Improve node monitoring and per-server alerts

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -6,6 +6,7 @@ import asyncio
 
 app = FastAPI()
 CHECK_INTERVAL = 60
+FAILURE_CONFIRMATION = 120  # время подтверждения падения ноды (сек)
 ALERTS_ENABLED = False
 ALERT_SENT = False
 BOT_ALERT_URL = "http://91.108.246.138:8080/alert"
@@ -13,6 +14,9 @@ ALERT_DB_PATH = os.path.join(os.path.dirname(__file__), "alerts.db")
 COMPOSE_PATH = os.path.expanduser("~/infernet-container-starter/deploy/docker-compose.yaml")
 print("📁 Current working dir:", os.getcwd())
 print("📄 Full DB path:", ALERT_DB_PATH)
+
+# словарь времени первого падения ноды
+failure_times = {}
 
 # === Ноды ===
 NODE_SYSTEMD = {
@@ -268,6 +272,7 @@ def monitor_nodes():
 
     while True:
         failed = set()
+        now = time.time()
 
         # === Systemd
         for name in installed_nodes:
@@ -334,15 +339,19 @@ def monitor_nodes():
                 failed.add("Gaia")
 
 
-        # === Отправка алертов
-        for name in failed:
-            if ALERTS_ENABLED and not was_already_reported(name):
-                send_alert(name)
-                mark_alert(name, True)
-
+        # === Отправка алертов с проверкой повторного запуска
         for name in installed_nodes:
-            if name not in failed:
-                mark_alert(name, False)
+            if name in failed:
+                if name not in failure_times:
+                    failure_times[name] = now
+                elif now - failure_times[name] >= FAILURE_CONFIRMATION:
+                    if ALERTS_ENABLED and not was_already_reported(name):
+                        send_alert(name)
+                        mark_alert(name, True)
+            else:
+                failure_times.pop(name, None)
+                if was_already_reported(name):
+                    mark_alert(name, False)
 
         time.sleep(CHECK_INTERVAL)
 

--- a/database/db.py
+++ b/database/db.py
@@ -11,9 +11,15 @@ async def init_db():
                 token TEXT,
                 ip TEXT,
                 name TEXT DEFAULT '',
-                note TEXT DEFAULT ''
+                note TEXT DEFAULT '',
+                alerts_enabled INTEGER DEFAULT 1
             )
         """)
+        # попытка добавить колонку alerts_enabled если база создана ранее
+        try:
+            await db.execute("ALTER TABLE servers ADD COLUMN alerts_enabled INTEGER DEFAULT 1")
+        except Exception:
+            pass
         await db.execute("""
             CREATE TABLE IF NOT EXISTS token_history (
                 token TEXT,
@@ -34,15 +40,24 @@ async def init_db():
         await db.commit()
 
 
-async def add_server(user_id: int, token: str, ip: str, name: str = ""):
+async def add_server(user_id: int, token: str, ip: str, name: str = "", alerts_enabled: int = 1):
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute("INSERT INTO servers (user_id, token, ip, name) VALUES (?, ?, ?, ?)", (user_id, token, ip, name))
+        await db.execute("INSERT INTO servers (user_id, token, ip, name, alerts_enabled) VALUES (?, ?, ?, ?, ?)", (user_id, token, ip, name, alerts_enabled))
         await db.execute("INSERT INTO token_history (token, ip) VALUES (?, ?)", (token, ip))
         await db.commit()
 
 async def get_servers(user_id: int):
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute("SELECT token, ip, name FROM servers WHERE user_id = ?", (user_id,))
+        return await cursor.fetchall()
+
+async def get_servers_extended(user_id: int):
+    """Вернуть список серверов вместе с флагом alerts_enabled"""
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "SELECT token, ip, name, alerts_enabled FROM servers WHERE user_id = ?",
+            (user_id,),
+        )
         return await cursor.fetchall()
 
 async def delete_server(user_id: int, token: str):
@@ -114,6 +129,20 @@ async def get_notify_alerts_for_user(user_id: int) -> bool:
             if row is None:
                 return False  # По умолчанию считаем True (или False — если хочешь отключать)
             return bool(row[0])
+
+async def toggle_server_alert(user_id: int, token: str):
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "UPDATE servers SET alerts_enabled = 1 - alerts_enabled WHERE user_id = ? AND token = ?",
+            (user_id, token),
+        )
+        await db.commit()
+
+async def get_server_alert_status(token: str) -> bool:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute("SELECT alerts_enabled FROM servers WHERE token = ?", (token,))
+        row = await cursor.fetchone()
+        return bool(row[0]) if row else False
 
 async def get_ip(token: str):
     async with aiosqlite.connect(DB_PATH) as db:

--- a/handlers/notifications.py
+++ b/handlers/notifications.py
@@ -1,10 +1,14 @@
 from aiogram import Router, F
 from aiogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
-from database.db import get_user_settings, toggle_notify_alerts, toggle_daily_report
+from database.db import (
+    get_user_settings,
+    toggle_daily_report,
+    get_servers_extended,
+    toggle_server_alert,
+)
 from aiogram import Bot
 from datetime import datetime
 from aiogram.types import User
-from database.db import get_servers
 import aiohttp
 
 
@@ -12,49 +16,53 @@ router = Router()
 bot: Bot = None
 
 
-def get_notification_keyboard(settings):
-    return InlineKeyboardMarkup(inline_keyboard=[
-        [InlineKeyboardButton(
-            text=f"Уведомления об упавших нодах: {'Вкл 🟢' if settings['notify_alerts'] else 'Выкл 🔴'}",
-            callback_data="toggle_alerts"
-        )],
-        [InlineKeyboardButton(
+def get_notification_keyboard(settings, servers):
+    keyboard = []
+    for token, ip, name, flag in servers:
+        title = name or ip
+        keyboard.append([
+            InlineKeyboardButton(
+                text=f"{title}: {'Вкл 🟢' if flag else 'Выкл 🔴'}",
+                callback_data=f"toggle_server_{token}"
+            )
+        ])
+    keyboard.append([
+        InlineKeyboardButton(
             text=f"Ежедневный отчёт: {'Вкл 🟢' if settings['daily_report'] else 'Выкл 🔴'}",
-            callback_data="toggle_daily"
-        )]
+            callback_data="toggle_daily",
+        )
     ])
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 @router.message(F.text == "/notifications")
 async def show_notifications(message: Message):
     settings = await get_user_settings(message.from_user.id)
-    await message.answer("Настройки уведомлений:", reply_markup=get_notification_keyboard(settings))
+    servers = await get_servers_extended(message.from_user.id)
+    await message.answer(
+        "Настройки уведомлений:",
+        reply_markup=get_notification_keyboard(settings, servers),
+    )
 
-@router.callback_query(F.data == "toggle_alerts")
-async def toggle_alerts(callback: CallbackQuery):
+@router.callback_query(F.data.startswith("toggle_server_"))
+async def toggle_server(callback: CallbackQuery):
     user: User = callback.from_user
     user_id = user.id
-    username = user.username or f"no_username:{user_id}"
+    token = callback.data.replace("toggle_server_", "")
 
-    await toggle_notify_alerts(user_id)
+    await toggle_server_alert(user_id, token)
+
+    # получение свежих данных для клавиатуры и рассылки на агент
+    servers = await get_servers_extended(user_id)
+    server = next((s for s in servers if s[0] == token), None)
+    if server:
+        ip = server[1]
+        flag = bool(server[3])
+        await send_alert_mode_to_agent(ip, token, flag)
+
     settings = await get_user_settings(user_id)
-
-    if settings["notify_alerts"]:
-        print(f"Уведомления о падающих нодах [FALL ALERTS ON] {user_id} | {username}")
-    else:
-        print(f"Уведомления о падающих нодах [FALL ALERTS OFF] {user_id} | {username}")
-
-    # 🔁 Рассылаем настройку на все сервера
-    servers = await get_servers(user_id)
-    for token, ip, _ in servers:
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"http://{ip}/set_alert_mode", json={"enabled": settings["notify_alerts"]}) as resp:
-                    await resp.read()
-            print(f"✅ Отправлен режим alerts_enabled={settings['notify_alerts']} на {ip}")
-        except Exception as e:
-            print(f"❌ Не удалось отправить на {ip}: {e}")
-
-    await callback.message.edit_reply_markup(reply_markup=get_notification_keyboard(settings))
+    await callback.message.edit_reply_markup(
+        reply_markup=get_notification_keyboard(settings, servers)
+    )
     await callback.answer("Изменено.")
 
 
@@ -76,7 +84,10 @@ async def toggle_daily(callback: CallbackQuery):
     else:
         print(f"Ежедневный репорт [DAILY OFF] {user_id} | {username}")
 
-    await callback.message.edit_reply_markup(reply_markup=get_notification_keyboard(settings))
+    servers = await get_servers_extended(user_id)
+    await callback.message.edit_reply_markup(
+        reply_markup=get_notification_keyboard(settings, servers)
+    )
     await callback.answer("Изменено.")
 
 async def send_alert_mode_to_agent(ip: str, token: str, alerts_enabled: bool):

--- a/handlers/server_manage.py
+++ b/handlers/server_manage.py
@@ -38,9 +38,9 @@ async def process_name(message: Message, state: FSMContext):
     name = message.text.strip().replace(" ", "_")[:16]
     data = await state.get_data()
     token = data["token"]
-    await add_server(message.chat.id, token, data["ip"], name)
-    await message.answer(f"✅ Сервер {data['ip']} добавлен как `{name}`", parse_mode="Markdown")
     flag = await get_notify_alerts_for_user(message.chat.id)
+    await add_server(message.chat.id, token, data["ip"], name, int(flag))
+    await message.answer(f"✅ Сервер {data['ip']} добавлен как `{name}`", parse_mode="Markdown")
     await send_alert_mode_to_agent(data["ip"], token, flag)
     await state.clear()
 


### PR DESCRIPTION
## Summary
- delay node failure alerts in agent to confirm persistent container failure
- store per-server alert settings in DB
- toggle alerts for each server in Telegram bot
- pass alert flag when adding a server

## Testing
- `python -m py_compile agent.py handlers/notifications.py handlers/server_manage.py database/db.py`

------
https://chatgpt.com/codex/tasks/task_b_6842fe331f7c83278e8d3f046a295be6