### PR TITLE
Add admin broadcast command

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -6,6 +6,7 @@ import asyncio
 
 app = FastAPI()
 CHECK_INTERVAL = 60
+FAILURE_CONFIRMATION = 120  # время подтверждения падения ноды (сек)
 ALERTS_ENABLED = False
 ALERT_SENT = False
 BOT_ALERT_URL = "http://91.108.246.138:8080/alert"
@@ -13,6 +14,9 @@ ALERT_DB_PATH = os.path.join(os.path.dirname(__file__), "alerts.db")
 COMPOSE_PATH = os.path.expanduser("~/infernet-container-starter/deploy/docker-compose.yaml")
 print("📁 Current working dir:", os.getcwd())
 print("📄 Full DB path:", ALERT_DB_PATH)
+
+# словарь времени первого падения ноды
+failure_times = {}
 
 # === Ноды ===
 NODE_SYSTEMD = {
@@ -208,7 +212,8 @@ def get_installed_nodes():
     # 2. processes
     for proc in psutil.process_iter(['cmdline']):
         try:
-            cmd = " ".join(proc.info['cmdline'])
+            cmdline = proc.info.get('cmdline') or []
+            cmd = " ".join(cmdline)
             for name, keyword in NODE_PROCESSES.items():
                 if keyword in cmd:
                     result.append(name)
@@ -268,6 +273,7 @@ def monitor_nodes():
 
     while True:
         failed = set()
+        now = time.time()
 
         # === Systemd
         for name in installed_nodes:
@@ -305,7 +311,8 @@ def monitor_nodes():
         active = set()
         for p in psutil.process_iter(['cmdline']):
             try:
-                cmd = " ".join(p.info['cmdline'])
+                cmdline = p.info.get('cmdline') or []
+                cmd = " ".join(cmdline)
                 for proc_name, keyword in NODE_PROCESSES.items():
                     if proc_name in installed_nodes and keyword in cmd:
                         active.add(proc_name)
@@ -334,15 +341,22 @@ def monitor_nodes():
                 failed.add("Gaia")
 
 
-        # === Отправка алертов
-        for name in failed:
-            if ALERTS_ENABLED and not was_already_reported(name):
-                send_alert(name)
-                mark_alert(name, True)
-
+        # === Отправка алертов с проверкой повторного запуска
         for name in installed_nodes:
-            if name not in failed:
-                mark_alert(name, False)
+            if name in failed:
+                if name not in failure_times:
+                    failure_times[name] = now
+                    print(f"⚠️ Нода {name} упала, жду {FAILURE_CONFIRMATION} сек")
+                elif now - failure_times[name] >= FAILURE_CONFIRMATION:
+                    if ALERTS_ENABLED and not was_already_reported(name):
+                        send_alert(name)
+                        mark_alert(name, True)
+                        print(f"❌ Нода {name} упала! Алерт отправлен")
+            else:
+                if name in failure_times:
+                    failure_times.pop(name, None)
+                if was_already_reported(name):
+                    mark_alert(name, False)
 
         time.sleep(CHECK_INTERVAL)
 
@@ -362,10 +376,10 @@ def monitor_disk():
         except Exception as e:
             print("Ошибка проверки Docker:", e)
 
-        # 🔁 Перезапуск Ritual если диск > 80%
-        if ritual_detected and percent > 80:
+        # 🔁 Перезапуск Ritual если диск > 95%
+        if ritual_detected and percent > 95:
             try:
-                print("📦 Диск > 80% и Ritual найден — перезапуск...")
+                print("📦 Диск > 95% и Ritual найден — перезапуск...")
 
                 # Остановка docker-compose
                 down_result = subprocess.call(["docker-compose", "-f", COMPOSE_PATH, "down"])
@@ -388,7 +402,7 @@ def monitor_disk():
                 print("❌ Ошибка перезапуска Ritual:", e)
 
         # 🔔 Алерт по диску
-        if percent >= 80 and not ALERT_SENT:
+        if percent >= 95 and not ALERT_SENT:
             try:
                 requests.post(BOT_ALERT_URL, json={
                     "token": get_token(),
@@ -400,7 +414,7 @@ def monitor_disk():
             except Exception as e:
                 print("Ошибка отправки алерта:", e)
 
-        elif percent < 78 and ALERT_SENT:
+        elif percent < 93 and ALERT_SENT:
             ALERT_SENT = False
 
         time.sleep(CHECK_INTERVAL)

--- a/database/db.py
+++ b/database/db.py
@@ -11,9 +11,15 @@ async def init_db():
                 token TEXT,
                 ip TEXT,
                 name TEXT DEFAULT '',
-                note TEXT DEFAULT ''
+                note TEXT DEFAULT '',
+                alerts_enabled INTEGER DEFAULT 1
             )
         """)
+        # попытка добавить колонку alerts_enabled если база создана ранее
+        try:
+            await db.execute("ALTER TABLE servers ADD COLUMN alerts_enabled INTEGER DEFAULT 1")
+        except Exception:
+            pass
         await db.execute("""
             CREATE TABLE IF NOT EXISTS token_history (
                 token TEXT,
@@ -34,15 +40,24 @@ async def init_db():
         await db.commit()
 
 
-async def add_server(user_id: int, token: str, ip: str, name: str = ""):
+async def add_server(user_id: int, token: str, ip: str, name: str = "", alerts_enabled: int = 1):
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute("INSERT INTO servers (user_id, token, ip, name) VALUES (?, ?, ?, ?)", (user_id, token, ip, name))
+        await db.execute("INSERT INTO servers (user_id, token, ip, name, alerts_enabled) VALUES (?, ?, ?, ?, ?)", (user_id, token, ip, name, alerts_enabled))
         await db.execute("INSERT INTO token_history (token, ip) VALUES (?, ?)", (token, ip))
         await db.commit()
 
 async def get_servers(user_id: int):
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute("SELECT token, ip, name FROM servers WHERE user_id = ?", (user_id,))
+        return await cursor.fetchall()
+
+async def get_servers_extended(user_id: int):
+    """Вернуть список серверов вместе с флагом alerts_enabled"""
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "SELECT token, ip, name, alerts_enabled FROM servers WHERE user_id = ?",
+            (user_id,),
+        )
         return await cursor.fetchall()
 
 async def delete_server(user_id: int, token: str):
@@ -114,6 +129,20 @@ async def get_notify_alerts_for_user(user_id: int) -> bool:
             if row is None:
                 return False  # По умолчанию считаем True (или False — если хочешь отключать)
             return bool(row[0])
+
+async def toggle_server_alert(user_id: int, token: str):
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "UPDATE servers SET alerts_enabled = 1 - alerts_enabled WHERE user_id = ? AND token = ?",
+            (user_id, token),
+        )
+        await db.commit()
+
+async def get_server_alert_status(token: str) -> bool:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute("SELECT alerts_enabled FROM servers WHERE token = ?", (token,))
+        row = await cursor.fetchone()
+        return bool(row[0]) if row else False
 
 async def get_ip(token: str):
     async with aiosqlite.connect(DB_PATH) as db:

--- a/fsm/states.py
+++ b/fsm/states.py
@@ -6,3 +6,8 @@ class CommentState(StatesGroup):
 class AddServerState(StatesGroup):
     waiting_for_ip = State()
     waiting_for_name = State()
+
+
+class BroadcastState(StatesGroup):
+    """State for admin broadcast confirmation"""
+    waiting_for_confirm = State()

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -1,0 +1,59 @@
+from aiogram import Router, F, Bot
+from aiogram.filters import Command
+from aiogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.fsm.context import FSMContext
+from fsm.states import BroadcastState
+from database.db import get_all_users
+
+router = Router()
+bot: Bot = None
+
+ADMIN_ID = 422955762
+
+@router.message(Command("send_mes"))
+async def send_mes(message: Message, state: FSMContext):
+    if message.from_user.id != ADMIN_ID:
+        return
+    parts = message.text.split(maxsplit=1)
+    if len(parts) < 2:
+        await message.answer("Использование: /send_mes <сообщение>")
+        return
+    text = parts[1]
+    await state.set_state(BroadcastState.waiting_for_confirm)
+    await state.set_data({"text": text})
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="✅ Отправить", callback_data="broadcast_confirm")],
+            [InlineKeyboardButton(text="❌ Отмена", callback_data="broadcast_cancel")],
+        ]
+    )
+    await message.answer(f"Отправить сообщение всем пользователям?\n\n{text}", reply_markup=keyboard)
+
+
+@router.callback_query(F.data == "broadcast_confirm")
+async def broadcast_confirm(callback: CallbackQuery, state: FSMContext):
+    if callback.from_user.id != ADMIN_ID:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+    data = await state.get_data()
+    text = data.get("text")
+    await state.clear()
+    await callback.message.edit_text("⏳ Рассылка...")
+    users = await get_all_users()
+    count = 0
+    for uid in users:
+        try:
+            await bot.send_message(uid, text)
+            count += 1
+        except Exception as e:
+            print(f"Не удалось отправить сообщение пользователю {uid}: {e}")
+    await callback.message.edit_text(f"✅ Рассылка завершена. Отправлено {count} пользователям.")
+
+
+@router.callback_query(F.data == "broadcast_cancel")
+async def broadcast_cancel(callback: CallbackQuery, state: FSMContext):
+    if callback.from_user.id != ADMIN_ID:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+    await state.clear()
+    await callback.message.edit_text("Рассылка отменена.")

--- a/handlers/alerts.py
+++ b/handlers/alerts.py
@@ -26,7 +26,7 @@ async def handle_alert(request: Request):
     if message:
         text = f"⚠️ Уведомление от `{name}` ({ip}):\n\n{message}"
     elif percent:
-        text = f"⚠️ Сервер `{name}` ({ip}) почти забит!\nДиск: {percent}%\n\n⏳ Перезапущен docker-compose Ritual."
+        text = f"⚠️ Сервер `{name}` ({ip}) почти забит (диск > 95%)!\nДиск: {percent}%\n\n⏳ Перезапущен docker-compose Ritual."
     else:
         text = f"⚠️ Пришёл неизвестный алерт с сервера `{name}` ({ip})"
 

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -3,13 +3,15 @@ from aiogram.types import Message, CallbackQuery
 from aiogram.filters import Command
 from utils.keyboard import get_info_keyboard, get_funcs_keyboard
 from database.db import get_user_settings
-from handlers.notifications import get_notification_keyboard
+from handlers.notifications import get_notifications_main_keyboard
 from aiogram.types import FSInputFile
 
 router = Router()
 
 @router.message(Command("start"))
 async def start_command(message: Message):
+    # Ensure the user exists in the database so that broadcasts reach them
+    await get_user_settings(message.from_user.id)
     photo = FSInputFile("welcome_monitor.png")
     await message.answer_photo(
         photo=photo,
@@ -47,8 +49,13 @@ async def info_callback(callback: CallbackQuery):
 
 @router.message(Command("notifications"))
 async def notifications_command(message: Message):
+    # загружаем настройки пользователя для отображения меню
     settings = await get_user_settings(message.from_user.id)
-    await message.answer("🔔 Настройки уведомлений", reply_markup=get_notification_keyboard(settings))
+    await message.answer(
+        "🔔 Настройки уведомлений",
+        # основной экран уведомлений требует только текущие настройки
+        reply_markup=get_notifications_main_keyboard(settings),
+    )
 
 @router.message(Command("funcs"))
 async def funcs_command(message: Message):

--- a/handlers/notifications.py
+++ b/handlers/notifications.py
@@ -1,10 +1,19 @@
 from aiogram import Router, F
-from aiogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
-from database.db import get_user_settings, toggle_notify_alerts, toggle_daily_report
+from aiogram.types import (
+    Message,
+    CallbackQuery,
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+)
+from database.db import (
+    get_user_settings,
+    toggle_daily_report,
+    get_servers_extended,
+    toggle_server_alert,
+)
 from aiogram import Bot
 from datetime import datetime
 from aiogram.types import User
-from database.db import get_servers
 import aiohttp
 
 
@@ -12,50 +21,94 @@ router = Router()
 bot: Bot = None
 
 
-def get_notification_keyboard(settings):
-    return InlineKeyboardMarkup(inline_keyboard=[
-        [InlineKeyboardButton(
-            text=f"Уведомления об упавших нодах: {'Вкл 🟢' if settings['notify_alerts'] else 'Выкл 🔴'}",
-            callback_data="toggle_alerts"
-        )],
-        [InlineKeyboardButton(
-            text=f"Ежедневный отчёт: {'Вкл 🟢' if settings['daily_report'] else 'Выкл 🔴'}",
-            callback_data="toggle_daily"
-        )]
+def get_notifications_main_keyboard(settings) -> InlineKeyboardMarkup:
+    """Keyboard with main notification options"""
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Настроить уведомления по серверам",
+                    callback_data="manage_alerts",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=f"Ежедневный отчёт: {'Вкл 🟢' if settings['daily_report'] else 'Выкл 🔴'}",
+                    callback_data="toggle_daily",
+                )
+            ],
+        ]
+    )
+
+
+def get_notification_keyboard(settings, servers):
+    keyboard = []
+    for token, ip, name, flag in servers:
+        title = name or ip
+        keyboard.append([
+            InlineKeyboardButton(
+                text=f"{title}: {'Вкл 🟢' if flag else 'Выкл 🔴'}",
+                callback_data=f"toggle_server_{token}"
+            )
+        ])
+    keyboard.append([
+        InlineKeyboardButton(text="🔙 Назад", callback_data="notifications_back")
     ])
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 @router.message(F.text == "/notifications")
 async def show_notifications(message: Message):
     settings = await get_user_settings(message.from_user.id)
-    await message.answer("Настройки уведомлений:", reply_markup=get_notification_keyboard(settings))
+    await message.answer(
+        "🔔 Настройки уведомлений",
+        reply_markup=get_notifications_main_keyboard(settings),
+    )
 
-@router.callback_query(F.data == "toggle_alerts")
-async def toggle_alerts(callback: CallbackQuery):
+
+@router.callback_query(F.data == "manage_alerts")
+async def manage_alerts(callback: CallbackQuery):
+    """Show keyboard with per-server alert toggles"""
+    user_id = callback.from_user.id
+    settings = await get_user_settings(user_id)
+    servers = await get_servers_extended(user_id)
+    await callback.message.delete()
+    await callback.message.answer(
+        "⚙️ Уведомления по серверам",
+        reply_markup=get_notification_keyboard(settings, servers),
+    )
+
+@router.callback_query(F.data.startswith("toggle_server_"))
+async def toggle_server(callback: CallbackQuery):
     user: User = callback.from_user
     user_id = user.id
-    username = user.username or f"no_username:{user_id}"
+    token = callback.data.replace("toggle_server_", "")
 
-    await toggle_notify_alerts(user_id)
+    await toggle_server_alert(user_id, token)
+
+    # получение свежих данных для клавиатуры и рассылки на агент
+    servers = await get_servers_extended(user_id)
+    server = next((s for s in servers if s[0] == token), None)
+    if server:
+        ip = server[1]
+        flag = bool(server[3])
+        await send_alert_mode_to_agent(ip, token, flag)
+
     settings = await get_user_settings(user_id)
-
-    if settings["notify_alerts"]:
-        print(f"Уведомления о падающих нодах [FALL ALERTS ON] {user_id} | {username}")
-    else:
-        print(f"Уведомления о падающих нодах [FALL ALERTS OFF] {user_id} | {username}")
-
-    # 🔁 Рассылаем настройку на все сервера
-    servers = await get_servers(user_id)
-    for token, ip, _ in servers:
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"http://{ip}/set_alert_mode", json={"enabled": settings["notify_alerts"]}) as resp:
-                    await resp.read()
-            print(f"✅ Отправлен режим alerts_enabled={settings['notify_alerts']} на {ip}")
-        except Exception as e:
-            print(f"❌ Не удалось отправить на {ip}: {e}")
-
-    await callback.message.edit_reply_markup(reply_markup=get_notification_keyboard(settings))
+    await callback.message.edit_reply_markup(
+        reply_markup=get_notification_keyboard(settings, servers)
+    )
     await callback.answer("Изменено.")
+
+
+@router.callback_query(F.data == "notifications_back")
+async def notifications_back(callback: CallbackQuery):
+    user_id = callback.from_user.id
+    settings = await get_user_settings(user_id)
+    await callback.message.delete()
+    await callback.message.answer(
+        "🔔 Настройки уведомлений",
+        reply_markup=get_notifications_main_keyboard(settings),
+    )
 
 
 
@@ -76,7 +129,9 @@ async def toggle_daily(callback: CallbackQuery):
     else:
         print(f"Ежедневный репорт [DAILY OFF] {user_id} | {username}")
 
-    await callback.message.edit_reply_markup(reply_markup=get_notification_keyboard(settings))
+    await callback.message.edit_reply_markup(
+        reply_markup=get_notifications_main_keyboard(settings)
+    )
     await callback.answer("Изменено.")
 
 async def send_alert_mode_to_agent(ip: str, token: str, alerts_enabled: bool):

--- a/handlers/server_manage.py
+++ b/handlers/server_manage.py
@@ -38,9 +38,9 @@ async def process_name(message: Message, state: FSMContext):
     name = message.text.strip().replace(" ", "_")[:16]
     data = await state.get_data()
     token = data["token"]
-    await add_server(message.chat.id, token, data["ip"], name)
-    await message.answer(f"✅ Сервер {data['ip']} добавлен как `{name}`", parse_mode="Markdown")
     flag = await get_notify_alerts_for_user(message.chat.id)
+    await add_server(message.chat.id, token, data["ip"], name, int(flag))
+    await message.answer(f"✅ Сервер {data['ip']} добавлен как `{name}`", parse_mode="Markdown")
     await send_alert_mode_to_agent(data["ip"], token, flag)
     await state.clear()
 

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import asyncio
 from config import API_TOKEN
 from database.db import init_db
 from handlers import commands, server_manage, navigation, alerts
+from handlers import admin
 from utils.tokens import rotate_tokens_loop
 from handlers import notifications
 from utils import reports
@@ -20,6 +21,7 @@ navigation.bot = bot
 server_manage.bot = bot
 notifications.bot = bot
 reports.bot = bot
+admin.bot = bot
 
 
 
@@ -38,6 +40,7 @@ dp.include_router(commands.router)
 dp.include_router(server_manage.router)
 dp.include_router(navigation.router)
 dp.include_router(notifications.router)
+dp.include_router(admin.router)
 
 # FastAPI роутер для /alert
 alerts.bot = bot  # пробросим бота в модуль


### PR DESCRIPTION
## Summary
- enable admin to broadcast messages with `/send_mes`
- integrate new admin router
- ensure users are registered on `/start` so broadcasts include them

## Testing
- `python -m py_compile agent.py handlers/notifications.py handlers/server_manage.py database/db.py handlers/commands.py handlers/admin.py fsm/states.py main.py`


------
https://chatgpt.com/codex/tasks/task_b_6842fe331f7c83278e8d3f046a295be6